### PR TITLE
Updated git-mirror chart to use metrics collector 0.3-1

### DIFF
--- a/charts/git-mirror/0.1.1/.helmignore
+++ b/charts/git-mirror/0.1.1/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/git-mirror/0.1.1/Chart.yaml
+++ b/charts/git-mirror/0.1.1/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "v0.3.0"
+description: A Helm chart for Kubernetes
+name: git-mirror
+version: 0.1.1

--- a/charts/git-mirror/0.1.1/templates/NOTES.txt
+++ b/charts/git-mirror/0.1.1/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.serve.ingress.enabled }}
+{{- range .Values.serve.ingress.hosts }}
+  http{{ if $.Values.serve.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.serve.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.serve.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "gitMirror.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.serve.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "gitMirror.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "gitMirror.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.serve.service.port }}
+{{- else if contains "ClusterIP" .Values.serve.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gitMirror.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}
+
+Source can be found here: https://github.com/rancher/git-mirror-docker

--- a/charts/git-mirror/0.1.1/templates/_helpers.tpl
+++ b/charts/git-mirror/0.1.1/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gitMirror.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gitMirror.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gitMirror.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/git-mirror/0.1.1/templates/git-analyze-deployment.yaml
+++ b/charts/git-mirror/0.1.1/templates/git-analyze-deployment.yaml
@@ -1,0 +1,43 @@
+# This is a start-once from rancher 1.x - not even on a cron schedule
+{{ if .Values.analyze.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "gitMirror.name" . }}-analyze
+    helm.sh/chart: {{ include "gitMirror.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ include "gitMirror.name" . }}-analyze
+spec:
+  replicas: {{ .Values.analyze.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "gitMirror.name" . }}-analyze
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "gitMirror.name" . }}-analyze
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      shareProcessNamespace: true
+      containers:
+      - name: analyze
+        args:
+        - -period
+        - 24h
+        image: {{ .Values.analyze.image.repository }}:{{ .Values.analyze.image.tag }}
+        imagePullPolicy: {{ .Values.analyze.image.pullPolicy }}
+        resources:
+          {{ toYaml .Values.analyze.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /var/log/nginx
+          name: efs-shared
+      restartPolicy: Always
+
+      volumes:
+      - name: efs-shared
+        persistentVolumeClaim:
+          claimName: efs-shared
+{{ end }}

--- a/charts/git-mirror/0.1.1/templates/git-mirror-deployment.yaml
+++ b/charts/git-mirror/0.1.1/templates/git-mirror-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "gitMirror.name" . }}-mirror
+    helm.sh/chart: {{ include "gitMirror.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ include "gitMirror.name" . }}-mirror
+spec:
+  replicas: {{ .Values.mirror.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "gitMirror.name" . }}-mirror
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "gitMirror.name" . }}-mirror
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      shareProcessNamespace: true
+      containers:
+      - name: mirror
+        env:
+        - name: MIRROR_DATA_DIR
+          value: {{ .Values.mirrorDataDir }}
+        - name: MIRROR_DEBUG
+          value: "{{ .Values.mirrorDebug }}"
+        - name: MIRROR_ETCD_ENDPOINTS
+          value: {{ .Values.mirrorEtcdEndpoints }}
+        - name: MIRROR_GITHUB_LISTEN_ADDR
+          value: {{ .Values.mirrorGithubListenAddr }}
+        - name: MIRROR_POLL_PERIOD
+          value: {{ .Values.mirrorPollPeriod }}
+        - name: MIRROR_REPO
+          value: {{ .Values.mirrorRepo }}
+        image: {{ .Values.mirror.image.repository }}:{{ .Values.mirror.image.tag }}
+        imagePullPolicy: {{ .Values.mirror.image.pullPolicy }}
+        resources:
+          {{ toYaml .Values.mirror.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: {{ .Values.mirrorDataDir }}
+          name: git-dir
+      - name: serve
+        env:
+        - name: SERVER_NAME
+          value: {{ .Values.serverName }}
+        - name: WORKER_CONNECTIONS
+          value: "{{ .Values.workerConnections }}"
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: {{ .Values.serve.image.repository }}:{{ .Values.serve.image.tag }}
+        imagePullPolicy: {{ .Values.serve.image.pullPolicy }}
+        resources:
+          {{ toYaml .Values.serve.resources | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        volumeMounts:
+        - mountPath: {{ .Values.mirrorDataDir }}
+          name: git-dir
+        - mountPath: /var/log/nginx
+          name: efs-shared
+      - name: logrotate
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        securityContext:
+          capabilities:
+            add:
+            - SYS_PTRACE
+        image: {{ .Values.logrotate.image.repository }}:{{ .Values.logrotate.image.tag }}
+        imagePullPolicy: {{ .Values.logrotate.image.pullPolicy }}
+        resources:
+          {{ toYaml .Values.logrotate.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /var/log/nginx
+          name: efs-shared
+
+      restartPolicy: Always
+      volumes:
+      - name: git-dir
+        emptyDir:
+          medium: Memory
+      - name: efs-shared
+        persistentVolumeClaim:
+          claimName: efs-shared

--- a/charts/git-mirror/0.1.1/templates/git-mirror-ingress.yaml
+++ b/charts/git-mirror/0.1.1/templates/git-mirror-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serve.ingress.enabled -}}
+{{- $fullName := include "gitMirror.fullname" . -}}
+{{- $ingressPath := .Values.serve.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-mirror
+  labels:
+    app.kubernetes.io/name: {{ include "gitMirror.name" . }}-mirror
+    helm.sh/chart: {{ include "gitMirror.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.serve.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.serve.ingress.tls }}
+  tls:
+  {{- range .Values.serve.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.serve.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}-mirror
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/git-mirror/0.1.1/templates/git-mirror-service.yaml
+++ b/charts/git-mirror/0.1.1/templates/git-mirror-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gitMirror.fullname" . }}-mirror
+  labels:
+    app.kubernetes.io/name: {{ include "gitMirror.name" . }}-mirror
+    helm.sh/chart: {{ include "gitMirror.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.serve.service.type }}
+  ports:
+    - port: {{ .Values.serve.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "gitMirror.name" . }}-mirror
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/git-mirror/0.1.1/templates/metrics-deployment.yaml
+++ b/charts/git-mirror/0.1.1/templates/metrics-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "gitMirror.name" . }}-metrics
+    helm.sh/chart: {{ include "gitMirror.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ include "gitMirror.name" . }}-metrics
+spec:
+  replicas: {{ .Values.metrics.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "gitMirror.name" . }}-metrics
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "gitMirror.name" . }}-metrics
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      shareProcessNamespace: true
+      containers:
+      - name: metrics
+        env:
+        - name: INFLUX_USER
+          valueFrom:
+            secretKeyRef:
+              name: metrics
+              key: INFLUX_USER
+        - name: INFLUX_PASS
+          valueFrom:
+            secretKeyRef:
+              name: metrics
+              key: INFLUX_PASS
+        - name: INFLUX_URL
+          valueFrom:
+            secretKeyRef:
+              name: metrics
+              key: INFLUX_URL
+        args:
+        - rancher-catalog-stats
+        - -filepath
+        - /var/log/nginx/access-*.log
+        - -influxurl
+        - $(INFLUX_URL)
+        - -influxdb
+        - catalog
+        - -daemon
+        - -poll
+        - -influxuser
+        - $(INFLUX_USER)
+        - -influxpass
+        - $(INFLUX_PASS)
+        image: {{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+        resources:
+          {{ toYaml .Values.metrics.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /var/log/nginx
+          name: efs-shared
+      restartPolicy: Always
+
+      volumes:
+      - name: efs-shared
+        persistentVolumeClaim:
+          claimName: efs-shared

--- a/charts/git-mirror/0.1.1/templates/nginx-logs-pvc.yaml
+++ b/charts/git-mirror/0.1.1/templates/nginx-logs-pvc.yaml
@@ -1,0 +1,14 @@
+# EFS
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-shared
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "efs"
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: efs

--- a/charts/git-mirror/0.1.1/values.yaml
+++ b/charts/git-mirror/0.1.1/values.yaml
@@ -1,0 +1,104 @@
+mirror:
+  replicaCount: 3
+  image:
+    repository: rancher/git-mirror
+    tag: v0.3.1
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+     cpu: 200m
+     memory: 256Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
+
+serve:
+  image:
+    repository: rancher/git-serve
+    tag: v0.3.1
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+     cpu: 200m
+     memory: 256Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "10254"
+      nginx.ingress.kubernetes.io/ssl-ciphers: "HIGH:!aNULL:!MD5"
+    path: /
+    hosts:
+      - git.rancher.io
+    tls:
+     - secretName: git-rancher-io-tls
+       hosts:
+         - git.rancher.io
+
+logrotate:
+  image:
+    repository: rancher/git-logrotate
+    tag: v0.3.1
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+     cpu: 200m
+     memory: 256Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
+
+analyze:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: rancher/git-analyze
+    tag: v0.3.1
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+     cpu: 200m
+     memory: 256Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
+
+metrics:
+  replicaCount: 1
+  image:
+    repository: rawmind/rancher-catalog-stats
+    tag: 0.3-1
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+     cpu: 200m
+     memory: 256Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
+
+nameOverride: ""
+fullnameOverride: ""
+
+mirrorDataDir: /var/git
+mirrorDebug: "false"
+mirrorEtcdEndpoints: http://etcd:2379
+mirrorGithubListenAddr: :4141
+mirrorPollPeriod: 5m
+mirrorRepo: https://github.com/rancher/rancher-catalog, https://github.com/rancher/community-catalog, https://github.com/rancher/infra-catalog, https://github.com/rancher/charts,https://github.com/rancher/system-charts
+serverName: git.rancher.io
+workerConnections: 4096
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Updated git-mirror chart to use metrics collector 0.3-1. This version able to refresh log files to analyze. This is needed due to nginx log files names are based on git-mirror pod names and they change if pods are restarted/redeployed.