### PR TITLE
adding charts for new telemetry-server versions

### DIFF
--- a/charts/telemetry/0.6.0/.helmignore
+++ b/charts/telemetry/0.6.0/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/telemetry/0.6.0/Chart.yaml
+++ b/charts/telemetry/0.6.0/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.6.0"
+description: A Helm chart for Kubernetes
+name: telemetry
+version: 0.6.0

--- a/charts/telemetry/0.6.0/templates/NOTES.txt
+++ b/charts/telemetry/0.6.0/templates/NOTES.txt
@@ -1,0 +1,10 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "telemetry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ $.Values.telemetryPort }}
+{{- end }}

--- a/charts/telemetry/0.6.0/templates/_helpers.tpl
+++ b/charts/telemetry/0.6.0/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telemetry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telemetry.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telemetry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/telemetry/0.6.0/templates/admin-deployment.yaml
+++ b/charts/telemetry/0.6.0/templates/admin-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "telemetry.name" . }}-admin
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.admin.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+      app.kubernetes.io/instance: {{ .Release.Name }}-admin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+        app.kubernetes.io/instance: {{ .Release.Name }}-admin
+    spec:
+      containers:
+      - args:
+        - server
+        - --xff
+        env:
+        - name: TELEMETRY_GA_TID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryGaTid
+        - name: TELEMETRY_PG_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgHost
+        - name: TELEMETRY_PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgPass
+        - name: TELEMETRY_PG_SSL
+          value: {{ .Values.telemetryPgSSL }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: telemetry
+        ports:
+          - name: http
+            containerPort: {{ .Values.telemetryPort }}
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/charts/telemetry/0.6.0/templates/admin-telemetryService.yaml
+++ b/charts/telemetry/0.6.0/templates/admin-telemetryService.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telemetry.fullname" . }}-admin
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin

--- a/charts/telemetry/0.6.0/templates/deployment.yaml
+++ b/charts/telemetry/0.6.0/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "telemetry.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "telemetry.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "telemetry.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+      - args:
+        - server
+        - --xff
+        env:
+        - name: TELEMETRY_GA_TID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryGaTid
+        - name: TELEMETRY_PG_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgHost
+        - name: TELEMETRY_PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgPass
+        - name: TELEMETRY_PG_SSL
+          value: {{ .Values.telemetryPgSSL }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: telemetry
+        ports:
+          - name: http
+            containerPort: {{ .Values.telemetryPort }}
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/charts/telemetry/0.6.0/templates/ingress.yaml
+++ b/charts/telemetry/0.6.0/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "telemetry.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $adminIngressPath := .Values.admin.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+          - path: {{ $adminIngressPath }}
+            backend:
+              serviceName: {{ $fullName }}-admin
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/telemetry/0.6.0/templates/secret.yaml
+++ b/charts/telemetry/0.6.0/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.secret.managed }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  labels:
+    app: {{ include "telemetry.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  telemetryGaTid: {{ .Values.secret.telemetryGaTid | b64enc | quote }}
+  telemetryPgPass: {{ .Values.secret.telemetryPgPass | b64enc | quote }}
+{{ end }}

--- a/charts/telemetry/0.6.0/templates/telemetryService.yaml
+++ b/charts/telemetry/0.6.0/templates/telemetryService.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telemetry.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/telemetry/0.6.0/values.yaml
+++ b/charts/telemetry/0.6.0/values.yaml
@@ -1,0 +1,56 @@
+secret:
+  name: telemetrysecrets
+  # Set this to true if you want to manage these secrets with helm
+  managed: false
+  telemetryGaTid: ""
+  telemetryPgPass: ""
+  telemetryPgHost: ""
+
+telemetryPgSSL: "require"
+telemetryPort: 8115
+
+replicaCount: 3
+admin:
+  replicaCount: 1
+  ingress:
+    path: /admin
+
+image:
+  repository: rancher/telemetry
+  tag: v0.6.0
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "10254"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/ssl-ciphers: "HIGH:!aNULL:!MD5"
+  path: /
+  hosts:
+    - telemetry.rancher.io
+  tls:
+   - secretName: telemetry-rancher-io-tls
+     hosts:
+       - telemetry.rancher.io
+
+resources:
+  limits:
+   cpu: 400m
+   memory: 512Mi
+  requests:
+   cpu: 300m
+   memory: 512Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/telemetry/0.6.2/.helmignore
+++ b/charts/telemetry/0.6.2/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/telemetry/0.6.2/Chart.yaml
+++ b/charts/telemetry/0.6.2/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.6.2"
+description: A Helm chart for Kubernetes
+name: telemetry
+version: 0.6.2

--- a/charts/telemetry/0.6.2/templates/NOTES.txt
+++ b/charts/telemetry/0.6.2/templates/NOTES.txt
@@ -1,0 +1,10 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "telemetry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ $.Values.telemetryPort }}
+{{- end }}

--- a/charts/telemetry/0.6.2/templates/_helpers.tpl
+++ b/charts/telemetry/0.6.2/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telemetry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "telemetry.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telemetry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/telemetry/0.6.2/templates/admin-deployment.yaml
+++ b/charts/telemetry/0.6.2/templates/admin-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "telemetry.name" . }}-admin
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.admin.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+      app.kubernetes.io/instance: {{ .Release.Name }}-admin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+        app.kubernetes.io/instance: {{ .Release.Name }}-admin
+    spec:
+      containers:
+      - args:
+        - server
+        - --xff
+        env:
+        - name: TELEMETRY_GA_TID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryGaTid
+        - name: TELEMETRY_PG_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgHost
+        - name: TELEMETRY_PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgPass
+        - name: TELEMETRY_PG_SSL
+          value: {{ .Values.telemetryPgSSL }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: telemetry
+        ports:
+          - name: http
+            containerPort: {{ .Values.telemetryPort }}
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/charts/telemetry/0.6.2/templates/admin-telemetryService.yaml
+++ b/charts/telemetry/0.6.2/templates/admin-telemetryService.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telemetry.fullname" . }}-admin
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}-admin
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin

--- a/charts/telemetry/0.6.2/templates/deployment.yaml
+++ b/charts/telemetry/0.6.2/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "telemetry.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "telemetry.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "telemetry.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+      - args:
+        - server
+        - --xff
+        env:
+        - name: TELEMETRY_GA_TID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryGaTid
+        - name: TELEMETRY_PG_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgHost
+        - name: TELEMETRY_PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secret.name }}
+              key: telemetryPgPass
+        - name: TELEMETRY_PG_SSL
+          value: {{ .Values.telemetryPgSSL }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: telemetry
+        ports:
+          - name: http
+            containerPort: {{ .Values.telemetryPort }}
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthcheck.html
+            port: http
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/charts/telemetry/0.6.2/templates/ingress.yaml
+++ b/charts/telemetry/0.6.2/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "telemetry.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $adminIngressPath := .Values.admin.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+          - path: {{ $adminIngressPath }}
+            backend:
+              serviceName: {{ $fullName }}-admin
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/charts/telemetry/0.6.2/templates/secret.yaml
+++ b/charts/telemetry/0.6.2/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.secret.managed }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  labels:
+    app: {{ include "telemetry.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  telemetryGaTid: {{ .Values.secret.telemetryGaTid | b64enc | quote }}
+  telemetryPgPass: {{ .Values.secret.telemetryPgPass | b64enc | quote }}
+{{ end }}

--- a/charts/telemetry/0.6.2/templates/telemetryService.yaml
+++ b/charts/telemetry/0.6.2/templates/telemetryService.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telemetry.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    helm.sh/chart: {{ include "telemetry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "telemetry.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/telemetry/0.6.2/values.yaml
+++ b/charts/telemetry/0.6.2/values.yaml
@@ -1,0 +1,56 @@
+secret:
+  name: telemetrysecrets
+  # Set this to true if you want to manage these secrets with helm
+  managed: false
+  telemetryGaTid: ""
+  telemetryPgPass: ""
+  telemetryPgHost: ""
+
+telemetryPgSSL: "require"
+telemetryPort: 8115
+
+replicaCount: 3
+admin:
+  replicaCount: 1
+  ingress:
+    path: /admin
+
+image:
+  repository: rancher/telemetry
+  tag: v0.6.2
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "10254"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/ssl-ciphers: "HIGH:!aNULL:!MD5"
+  path: /
+  hosts:
+    - telemetry.rancher.io
+  tls:
+   - secretName: telemetry-rancher-io-tls
+     hosts:
+       - telemetry.rancher.io
+
+resources:
+  limits:
+   cpu: 400m
+   memory: 512Mi
+  requests:
+   cpu: 300m
+   memory: 512Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
- added chart v0.6.0 which deploys telemetry-server v0.6.0
- added chart v0.6.2 which deploys telemetry-server v0.6.2

**Context**
chart v0.5.0 deploys telemetry-server v0.6.1 was released some years ago. 
However, telemetry-server v0.6.0 was only released a few months ago which is a little confusing.
So, for consistency,  the new chart versions have been changed to match the new telemetry-server versions.