### PR TITLE
specifying -amd64 arch in image tags

### DIFF
--- a/charts/telemetry/0.6.0/values.yaml
+++ b/charts/telemetry/0.6.0/values.yaml
@@ -17,7 +17,7 @@ admin:
 
 image:
   repository: rancher/telemetry
-  tag: v0.6.0
+  tag: v0.6.0-amd64
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/telemetry/0.6.2/values.yaml
+++ b/charts/telemetry/0.6.2/values.yaml
@@ -17,7 +17,7 @@ admin:
 
 image:
   repository: rancher/telemetry
-  tag: v0.6.2
+  tag: v0.6.2-amd64
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
referencing [v0.6.2-amd64](https://hub.docker.com/layers/rancher/telemetry/v0.6.2-amd64/images/sha256-1ef776ceec5c9468ed9677cb47ef8b81d76760d1617f3b38d9b7079811af65af?context=explore)